### PR TITLE
chore: bump .NET target to 9

### DIFF
--- a/src/UIL/UIL.csproj
+++ b/src/UIL/UIL.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/UIL.Tests/UIL.Tests.csproj
+++ b/tests/UIL.Tests/UIL.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- upgrade main project to .NET 9
- test project now targets .NET 9

## Testing
- `~/.dotnet/dotnet build src/UIL/UIL.csproj`
- `~/.dotnet/dotnet test tests/UIL.Tests/UIL.Tests.csproj` *(fails: System.OutOfMemoryException)*

------
https://chatgpt.com/codex/tasks/task_e_6892169e03ac8332838f0ec0b4df6f6d