### PR TITLE
Expose bound types from binder

### DIFF
--- a/src/UIL/Binding/IBinder.cs
+++ b/src/UIL/Binding/IBinder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UIL.Diagnostics;
 using UIL.Symbols;
 using UIL.Syntax;
@@ -8,5 +9,6 @@ public interface IBinder
 {
     DiagnosticBag Diagnostics { get; }
     void BindCompilationUnit(CompilationUnitSyntax syntax);
+    IReadOnlyDictionary<string, TypeSymbol> Types { get; }
     BoundBlockStatement BindMethod(MethodDeclarationSyntax syntax, out MethodSymbol symbol);
 }

--- a/src/UIL/Syntax/Parser.cs
+++ b/src/UIL/Syntax/Parser.cs
@@ -53,17 +53,24 @@ public sealed class Parser
         }
 
         var start = _position;
+
         if (char.IsDigit(_text[_position]))
         {
-            if (char.IsWhiteSpace(_text[_position]))
-            {
+            while (_position < _text.Length && char.IsDigit(_text[_position]))
                 _position++;
-                continue;
-            }
 
-            var start = _position;
+            var text = _text.Substring(start, _position - start);
+            int.TryParse(text, out var value);
+            return new SyntaxToken(SyntaxKind.NumberToken, start, text, value);
+        }
 
-            if (char.IsDigit(_text[_position]))
+        if (char.IsLetter(_text[_position]))
+        {
+            while (_position < _text.Length && char.IsLetter(_text[_position]))
+                _position++;
+
+            var text = _text.Substring(start, _position - start);
+            var kind = text switch
             {
                 "int" => SyntaxKind.IntKeyword,
                 "return" => SyntaxKind.ReturnKeyword,
@@ -125,8 +132,6 @@ public sealed class Parser
                 _position++;
                 return new SyntaxToken(SyntaxKind.IdentifierToken, start, _text.Substring(start,1), null);
         }
-
-        return new SyntaxToken(SyntaxKind.EndOfFileToken, _position, "", null);
     }
 
     private SyntaxToken MatchToken(SyntaxKind kind)

--- a/tests/UIL.Tests/TestCompiler.cs
+++ b/tests/UIL.Tests/TestCompiler.cs
@@ -27,7 +27,8 @@ internal static class TestCompiler
             throw new InvalidOperationException("Parser reported diagnostics: " + string.Join(", ", tree.Diagnostics));
 
         var binder = new Binder();
-        var body = binder.BindMethod(tree.Root.Member, out var method);
+        var methodSyntax = (MethodDeclarationSyntax)tree.Root.Members.Single();
+        var body = binder.BindMethod(methodSyntax, out var method);
         if (binder.Diagnostics.Any())
             throw new InvalidOperationException("Binder reported diagnostics: " + string.Join(", ", binder.Diagnostics));
 


### PR DESCRIPTION
## Summary
- expose bound type table through `IBinder` to support type definition tests
- fix parser tokenization logic and update tests to bind methods from compilation units

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689229975a8083328c654d26cfde0e72